### PR TITLE
Remove miniumum length on account name

### DIFF
--- a/src/OroCRM/Bundle/AccountBundle/Resources/config/validation.yml
+++ b/src/OroCRM/Bundle/AccountBundle/Resources/config/validation.yml
@@ -3,7 +3,6 @@ OroCRM\Bundle\AccountBundle\Entity\Account:
         name:
             - NotBlank:     ~
             - Length:
-                min:        3
                 max:        255
         organization:
             - NotBlank:     ~


### PR DESCRIPTION
There is no reason why an account name should be minimum 3 chars. Companies like 3M for instance can not be submitted to the crm at the moment. Since there is already a notblank validation I propose to remove the min length validation rule.
